### PR TITLE
Enabled mdt_user permissions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 from distutils.version import LooseVersion
 from setuptools import setup, find_packages
 
-version = '0.12'
+version = '0.12.0.1'
 
 # ***************************************************************************
 # ************************** Python version *********************************

--- a/src/fobi/__init__.py
+++ b/src/fobi/__init__.py
@@ -1,5 +1,5 @@
 __title__ = 'django-fobi'
-__version__ = '0.12'
+__version__ = '0.12.0.1'
 __build__ = 0x000089
 __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'
 __copyright__ = '2014-2017 Artur Barseghyan'

--- a/src/fobi/decorators.py
+++ b/src/fobi/decorators.py
@@ -47,7 +47,9 @@ def permissions_required(perms, satisfy=DEFAULT_SATISFY, login_url=None,
     """
     if apps.is_installed("mdt_users"):
         # Always allow access if mdt_users app is installed because mdt_user permissions will be applied
-        return user_passes_test(True, login_url=login_url)
+        def check_perms(user):
+            return True
+        return user_passes_test(check_perms, login_url=login_url)
     assert satisfy in (SATISFY_ANY, SATISFY_ALL)
 
     if SATISFY_ALL == satisfy:
@@ -131,5 +133,7 @@ def has_mdt_permission(permission_name):
 
         return user_passes_test(check_perms)
     else:
+        def check_perms(user):
+            return True
         # Always allow access if mdt_users app is not installed because fobi permissions will be applied
-        return user_passes_test(True)
+        return user_passes_test(check_perms)

--- a/src/fobi/decorators.py
+++ b/src/fobi/decorators.py
@@ -1,3 +1,4 @@
+from django.apps import apps
 from django.core.exceptions import PermissionDenied
 from django.contrib.auth.decorators import user_passes_test
 
@@ -44,6 +45,9 @@ def permissions_required(perms, satisfy=DEFAULT_SATISFY, login_url=None,
     >>> def edit_dashboard(request):
     >>>     # your code
     """
+    if apps.is_installed("mdt_users"):
+        # Always allow access if mdt_users app is installed because mdt_user permissions will be applied
+        return user_passes_test(True, login_url=login_url)
     assert satisfy in (SATISFY_ANY, SATISFY_ALL)
 
     if SATISFY_ALL == satisfy:
@@ -114,3 +118,18 @@ def any_permission_required(perms, login_url=None, raise_exception=False):
     return permissions_required(perms, satisfy=SATISFY_ANY,
                                 login_url=login_url,
                                 raise_exception=raise_exception)
+
+                                
+def has_mdt_permission(permission_name):
+    """Check for the permissions given by mdt_users application."""
+    if apps.is_installed("mdt_users"):
+        from mdt_users.verifications import has_permission
+        def check_perms(user):
+            if not has_permission(user, permission_name):
+                raise PermissionDenied
+            return True
+
+        return user_passes_test(check_perms)
+    else:
+        # Always allow access if mdt_users app is not installed because fobi permissions will be applied
+        return user_passes_test(True)

--- a/src/fobi/views.py
+++ b/src/fobi/views.py
@@ -42,7 +42,7 @@ from .constants import (
     CALLBACK_FORM_VALID_AFTER_FORM_HANDLERS,
     CALLBACK_FORM_INVALID
 )
-from .decorators import permissions_required, SATISFY_ALL, SATISFY_ANY
+from .decorators import has_mdt_permission, permissions_required, SATISFY_ALL, SATISFY_ANY
 from .dynamic import assemble_form_class
 from .form_importers import (
     ensure_autodiscover as ensure_importers_autodiscover,
@@ -244,6 +244,7 @@ dashboard_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_read')
 @permissions_required(satisfy=SATISFY_ANY, perms=dashboard_permissions)
 def dashboard(request, theme=None, template_name=None):
     """Dashboard.
@@ -291,6 +292,7 @@ wizards_dashboard_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_read')
 @permissions_required(satisfy=SATISFY_ANY, perms=wizards_dashboard_permissions)
 def form_wizards_dashboard(request, theme=None, template_name=None):
     """Dashboard for form wizards.
@@ -301,7 +303,6 @@ def form_wizards_dashboard(request, theme=None, template_name=None):
     :return django.http.HttpResponse:
     """
     form_wizard_entries = FormWizardEntry._default_manager \
-        .filter(user__pk=request.user.pk) \
         .select_related('user')
 
     context = {
@@ -344,6 +345,7 @@ create_form_entry_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL, perms=create_form_entry_permissions)
 def create_form_entry(request, theme=None, template_name=None):
     """Create form entry.
@@ -412,6 +414,7 @@ edit_form_entry_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ANY, perms=edit_form_entry_permissions)
 def edit_form_entry(request, form_entry_id, theme=None, template_name=None):
     """Edit form entry.
@@ -595,6 +598,7 @@ delete_form_entry_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL,
                       perms=delete_form_entry_permissions)
 def delete_form_entry(request, form_entry_id, template_name=None):
@@ -607,7 +611,7 @@ def delete_form_entry(request, form_entry_id, template_name=None):
     """
     try:
         obj = FormEntry._default_manager \
-            .get(pk=form_entry_id, user__pk=request.user.pk)
+            .get(pk=form_entry_id)
     except ObjectDoesNotExist as err:
         raise Http404(ugettext("Form entry not found."))
 
@@ -627,6 +631,7 @@ def delete_form_entry(request, form_entry_id, template_name=None):
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.add_formelemententry')
 def add_form_element_entry(request,
                            form_entry_id,
@@ -759,6 +764,7 @@ def add_form_element_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.change_formelemententry')
 def edit_form_element_entry(request,
                             form_element_entry_id,
@@ -864,6 +870,7 @@ def edit_form_element_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.delete_formelemententry')
 def delete_form_element_entry(request, form_element_entry_id):
     """Delete form element entry.
@@ -890,6 +897,7 @@ def delete_form_element_entry(request, form_element_entry_id):
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.add_formhandlerentry')
 def add_form_handler_entry(request,
                            form_entry_id,
@@ -1017,6 +1025,7 @@ def add_form_handler_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.change_formhandlerentry')
 def edit_form_handler_entry(request,
                             form_handler_entry_id,
@@ -1111,6 +1120,7 @@ def edit_form_handler_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.delete_formhandlerentry')
 def delete_form_handler_entry(request, form_handler_entry_id):
     """Delete form handler entry.
@@ -1149,6 +1159,7 @@ create_form_wizard_entry_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL,
                       perms=create_form_wizard_entry_permissions)
 def create_form_wizard_entry(request, theme=None, template_name=None):
@@ -1224,6 +1235,7 @@ edit_form_wizard_entry_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ANY,
                       perms=edit_form_wizard_entry_permissions)
 def edit_form_wizard_entry(request, form_wizard_entry_id, theme=None,
@@ -1393,6 +1405,7 @@ delete_form_wizard_entry_permissions = [
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL,
                       perms=delete_form_wizard_entry_permissions)
 def delete_form_wizard_entry(request, form_wizard_entry_id,
@@ -1762,6 +1775,7 @@ def form_wizard_entry_submitted(request, form_wizard_entry_slug=None,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.add_formwizardformentry')
 def add_form_wizard_form_entry(request,
                                form_wizard_entry_id,
@@ -1859,6 +1873,7 @@ def add_form_wizard_form_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.delete_formwizardformentry')
 def delete_form_wizard_form_entry(request, form_wizard_form_entry_id):
     """Delete form wizard form entry.
@@ -1911,6 +1926,7 @@ def delete_form_wizard_form_entry(request, form_wizard_form_entry_id):
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.add_formwizardhandlerentry')
 def add_form_wizard_handler_entry(request,
                                   form_wizard_entry_id,
@@ -2046,6 +2062,7 @@ def add_form_wizard_handler_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.change_formwizardhandlerentry')
 def edit_form_wizard_handler_entry(request,
                                    form_wizard_handler_entry_id,
@@ -2147,6 +2164,7 @@ def edit_form_wizard_handler_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permission_required('fobi.delete_formwizardhandlerentry')
 def delete_form_wizard_handler_entry(request, form_wizard_handler_entry_id):
     """Delete form handler entry.
@@ -2366,6 +2384,7 @@ def form_entry_submitted(request, form_entry_slug=None, template_name=None):
 
 
 @login_required
+@has_mdt_permission('admin_read')
 @permissions_required(satisfy=SATISFY_ALL, perms=create_form_entry_permissions)
 def export_form_entry(request, form_entry_id, template_name=None):
     """Export form entry to JSON.
@@ -2430,6 +2449,7 @@ def export_form_entry(request, form_entry_id, template_name=None):
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL, perms=create_form_entry_permissions)
 def import_form_entry(request, template_name=None):
     """Import form entry.
@@ -2574,6 +2594,7 @@ def import_form_entry(request, template_name=None):
 
 
 @login_required
+@has_mdt_permission('admin_read')
 @permissions_required(satisfy=SATISFY_ALL,
                       perms=create_form_wizard_entry_permissions)
 def export_form_wizard_entry(request,
@@ -2635,6 +2656,7 @@ def export_form_wizard_entry(request,
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL,
                       perms=create_form_wizard_entry_permissions)
 def import_form_wizard_entry(request, template_name=None):
@@ -2781,6 +2803,7 @@ def import_form_wizard_entry(request, template_name=None):
 
 
 @login_required
+@has_mdt_permission('admin_write')
 @permissions_required(satisfy=SATISFY_ALL, perms=create_form_entry_permissions)
 def form_importer(request,
                   form_importer_plugin_uid,

--- a/src/fobi/views.py
+++ b/src/fobi/views.py
@@ -148,7 +148,6 @@ def _delete_plugin_entry(request,
                          message,
                          html_anchor):
     """Abstract delete entry.
-
     :param django.http.HttpRequest request:
     :param int entry_id:
     :param fobi.models.AbstractPluginEntry entry_model_cls: Subclass of
@@ -159,26 +158,29 @@ def _delete_plugin_entry(request,
     """
     try:
         obj = entry_model_cls._default_manager \
-            .select_related('form_entry') \
-            .get(pk=entry_id)
-    except ObjectDoesNotExist as e:
-        raise Http404(_("{0} not found.").format(EntryModel._meta.verbose_name))
-
-
-        form_entry = obj.form_entry
-        plugin = obj.get_plugin(request=request)
-        plugin.request = request
-
-        plugin._delete_plugin_data()
-
-        obj.delete()
-
-        messages.info(request, message.format(plugin.name))
-
-        redirect_url = reverse(
-            'fobi.edit_form_entry', kwargs={'form_entry_id': form_entry.pk}
+                             .select_related('form_entry') \
+                             .get(pk=entry_id)
+    except ObjectDoesNotExist as err:
+        raise Http404(
+            ugettext("{0} not found.").format(
+                entry_model_cls._meta.verbose_name
+            )
         )
-        return redirect("{0}{1}".format(redirect_url, html_anchor))
+
+    form_entry = obj.form_entry
+    plugin = obj.get_plugin(request=request)
+    plugin.request = request
+
+    plugin._delete_plugin_data()
+
+    obj.delete()
+
+    messages.info(request, message.format(plugin.name))
+
+    redirect_url = reverse(
+        'fobi.edit_form_entry', kwargs={'form_entry_id': form_entry.pk}
+    )
+    return redirect("{0}{1}".format(redirect_url, html_anchor))
 
 
 def _delete_wizard_plugin_entry(request,

--- a/src/fobi/views.py
+++ b/src/fobi/views.py
@@ -12,7 +12,7 @@ import simplejson as json
 
 from django.db import models, IntegrityError
 from django.contrib import messages
-from django.contrib.auth.decorators import login_required, permission_required
+from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ObjectDoesNotExist
 from django.core.files.storage import FileSystemStorage
 from django.forms import ValidationError
@@ -632,7 +632,7 @@ def delete_form_entry(request, form_entry_id, template_name=None):
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.add_formelemententry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.add_formelemententry'])
 def add_form_element_entry(request,
                            form_entry_id,
                            form_element_plugin_uid,
@@ -765,7 +765,7 @@ def add_form_element_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.change_formelemententry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.change_formelemententry'])
 def edit_form_element_entry(request,
                             form_element_entry_id,
                             theme=None,
@@ -871,7 +871,7 @@ def edit_form_element_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.delete_formelemententry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.delete_formelemententry'])
 def delete_form_element_entry(request, form_element_entry_id):
     """Delete form element entry.
 
@@ -898,7 +898,7 @@ def delete_form_element_entry(request, form_element_entry_id):
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.add_formhandlerentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.add_formhandlerentry'])
 def add_form_handler_entry(request,
                            form_entry_id,
                            form_handler_plugin_uid,
@@ -1026,7 +1026,7 @@ def add_form_handler_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.change_formhandlerentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.change_formhandlerentry'])
 def edit_form_handler_entry(request,
                             form_handler_entry_id,
                             theme=None,
@@ -1121,7 +1121,7 @@ def edit_form_handler_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.delete_formhandlerentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.delete_formhandlerentry'])
 def delete_form_handler_entry(request, form_handler_entry_id):
     """Delete form handler entry.
 
@@ -1776,7 +1776,7 @@ def form_wizard_entry_submitted(request, form_wizard_entry_slug=None,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.add_formwizardformentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.add_formwizardformentry'])
 def add_form_wizard_form_entry(request,
                                form_wizard_entry_id,
                                form_entry_id,
@@ -1874,7 +1874,7 @@ def add_form_wizard_form_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.delete_formwizardformentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.delete_formwizardformentry'])
 def delete_form_wizard_form_entry(request, form_wizard_form_entry_id):
     """Delete form wizard form entry.
 
@@ -1927,7 +1927,7 @@ def delete_form_wizard_form_entry(request, form_wizard_form_entry_id):
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.add_formwizardhandlerentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.add_formwizardhandlerentry'])
 def add_form_wizard_handler_entry(request,
                                   form_wizard_entry_id,
                                   form_wizard_handler_plugin_uid,
@@ -2063,7 +2063,7 @@ def add_form_wizard_handler_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.change_formwizardhandlerentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.change_formwizardhandlerentry'])
 def edit_form_wizard_handler_entry(request,
                                    form_wizard_handler_entry_id,
                                    theme=None,
@@ -2165,7 +2165,7 @@ def edit_form_wizard_handler_entry(request,
 
 @login_required
 @has_mdt_permission('admin_write')
-@permission_required('fobi.delete_formwizardhandlerentry')
+@permissions_required(satisfy=SATISFY_ALL, perms=['fobi.delete_formwizardhandlerentry'])
 def delete_form_wizard_handler_entry(request, form_wizard_handler_entry_id):
     """Delete form handler entry.
 

--- a/src/fobi/views.py
+++ b/src/fobi/views.py
@@ -159,7 +159,8 @@ def _delete_plugin_entry(request,
     """
     try:
         obj = entry_model_cls._default_manager \
-            .select_related('form_entry') 
+            .select_related('form_entry') \
+            .get(pk=entry_id)
     except ObjectDoesNotExist as e:
         raise Http404(_("{0} not found.").format(EntryModel._meta.verbose_name))
 
@@ -198,8 +199,7 @@ def _delete_wizard_plugin_entry(request,
     try:
         obj = entry_model_cls._default_manager \
             .select_related('form_wizard_entry') \
-            .get(pk=entry_id,
-                 form_wizard_entry__user__pk=request.user.pk)
+            .get(pk=entry_id)
     except ObjectDoesNotExist as err:
         raise Http404(
             ugettext("{0} not found.").format(


### PR DESCRIPTION
If mdt_users app is installed django-fobi will use permissions from mdt_users app and ignore regular permissions provided by django-fobi.
A mdt_user with _admin_read_ and _admin_write_ permissions is able to use fobi without restrictions.
Mdt_users that do not have _admin_read_ and _admin_write_ permissions will get 403 page displayed when accessing fobi urls.

If mdt_users app is not installed django-fobi will use regular permissions provided by django-fobi and ignore permissions provided by mdt_users app.

Added ability to read forms and write to forms that are created by other users.